### PR TITLE
use UUIDs instead of counting

### DIFF
--- a/src/basketfactory.cpp
+++ b/src/basketfactory.cpp
@@ -24,6 +24,7 @@
 #include <QtCore/QTextStream>
 #include <QtGui/QGraphicsView>
 #include <QtXml/QDomElement>
+#include <QUuid>
 
 #include <KDE/KLocale>
 #include <KDE/KMessageBox>
@@ -44,13 +45,12 @@ QString BasketFactory::newFolderName()
     QString fullPath;
     QDir    dir;
 
-    for (int i = 1; ; ++i) {
-        folderName = "basket" + QString::number(i) + "/";
+    do {
+        QString id = QUuid::createUuid().toString().remove(QRegExp("[{}]")); // QTBUG-885
+        folderName = "basket-" + id + "/";
         fullPath   = Global::basketsFolder() + folderName;
         dir        = QDir(fullPath);
-        if (! dir.exists())   // OK : The folder do not yet exists :
-            break;            //  We've found one !
-    }
+    } while (dir.exists());   // Should run only once
 
     return folderName;
 }

--- a/src/notefactory.cpp
+++ b/src/notefactory.cpp
@@ -37,6 +37,7 @@
 #include <QtGui/QTextDocument> //For Qt::mightBeRichText(...)
 #include <QtGui/QBitmap> //For createHeuristicMask
 #include <QtCore/qnamespace.h>
+#include <QUuid>
 
 #include <KDE/KUrl>
 #include <KDE/KMimeType>
@@ -864,20 +865,17 @@ QString NoteFactory::fileNameForNewNote(BasketScene *parent, const QString &want
 //  (extension willn't be used for that case)
 QString NoteFactory::createFileForNewNote(BasketScene *parent, const QString &extension, const QString &wantedName)
 {
-    static int nb = 1;
-
     QString fileName;
     QString fullName;
 
     if (wantedName.isEmpty()) { // TODO: fileNameForNewNote(parent, "note1."+extension);
-        QDir dir;
-        for (/*int nb = 1*/; ; ++nb) { // TODO: FIXME: If overflow ???
-            fileName = "note" + QString::number(nb)/*.rightJustified(5, '0')*/ + "." + extension;
+        QDir file;
+        do {
+	    QString id = QUuid::createUuid().toString().remove(QRegExp("[{}]")); // QTBUG-885
+            fileName = "note-" + id + "." + extension;
             fullName = parent->fullPath() + fileName;
-            dir = QDir(fullName);
-            if (! dir.exists(fullName))
-                break;
-        }
+            file = QDir(fullName);
+	} while (file.exists(fullName)); // should run only once
     } else {
         fileName = fileNameForNewNote(parent, wantedName);
         fullName = parent->fullPath() + fileName;


### PR DESCRIPTION
This improves the usability of basket in distributed environments, e. g.
when using a VCS like git to synchronize between multiple installations.
